### PR TITLE
feat(wiping): switch to safer default

### DIFF
--- a/final/configuration.nix
+++ b/final/configuration.nix
@@ -19,7 +19,7 @@
     extraGroups = [ "wheel" ]; # Enable ‘sudo’ for the user.
   };
 
-  boot.initrd.postDeviceCommands = lib.mkAfter ''
+  boot.initrd.postResumeCommands = lib.mkAfter ''
     mkdir /btrfs_tmp
     mount /dev/root_vg/root /btrfs_tmp
     if [[ -e /btrfs_tmp/root ]]; then


### PR DESCRIPTION
Use of boot.initdr.postDeviceCommands can cause FS corruption with hibernation

See https://github.com/nix-community/impermanence

Closes #3